### PR TITLE
switched PUT -> POST for object uploads

### DIFF
--- a/push_to_holmes.go
+++ b/push_to_holmes.go
@@ -496,8 +496,7 @@ func buildRequest(uri string, params url.Values, hash string) (*http.Request, er
 		return nil, err
 	}
 
-	request, err := http.NewRequest("PUT", uri, body)
-	//request, err := http.NewRequest("POST", uri, body)
+	request, err := http.NewRequest("POST", uri, body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Since switching to storage v2, object uploads use POST instead of PUT.
This Pull request ensures compatibility to the major pull request for Holmes-Gateway
https://github.com/HolmesProcessing/Holmes-Gateway/pull/35
which builds upon storage v2.